### PR TITLE
Improve remote fetch

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -110,7 +110,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT mount
 ## Pointing apt to public apt mirrors and getting latest packages, needed for latest security updates
 scripts/build_mirror_config.sh files/apt $CONFIGURED_ARCH $IMAGE_DISTRO 
 sudo cp files/apt/sources.list.$CONFIGURED_ARCH $FILESYSTEM_ROOT/etc/apt/sources.list
-sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
+sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages,retries-count},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
 
 ## Note: set lang to prevent locale warnings in your chroot
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y update

--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -30,6 +30,7 @@ COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 
 # Update apt cache and
 # pre-install fundamental packages

--- a/dockers/docker-base-buster/apt-retries-count
+++ b/dockers/docker-base-buster/apt-retries-count
@@ -1,0 +1,1 @@
+Acquire::Retries "20";

--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -30,6 +30,7 @@ COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 
 # Update apt cache and
 # pre-install fundamental packages

--- a/dockers/docker-base-stretch/apt-retries-count
+++ b/dockers/docker-base-stretch/apt-retries-count
@@ -1,0 +1,1 @@
+Acquire::Retries "20";

--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -38,6 +38,7 @@ COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 COPY ["sources.list", "/etc/apt/sources.list"]
 {% endif %}
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 RUN apt-get update
 
 # Pre-install fundamental packages

--- a/dockers/docker-base/apt-retries-count
+++ b/dockers/docker-base/apt-retries-count
@@ -1,0 +1,1 @@
+Acquire::Retries "20";

--- a/files/apt/apt.conf.d/apt-retries-count
+++ b/files/apt/apt.conf.d/apt-retries-count
@@ -1,0 +1,1 @@
+Acquire::Retries "20";

--- a/rules/tacacs.dep
+++ b/rules/tacacs.dep
@@ -1,7 +1,7 @@
 #DPKG FRK
 
 SPATH       := $($(LIBTAC2)_SRC_PATH)
-DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/tacacs.mk rules/tacacs.dep   
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/tacacs.mk rules/tacacs.dep 
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH))
 
@@ -32,4 +32,16 @@ DEP_FILES   += $(shell git ls-files $(SPATH))
 $(BASH_TACPLUS)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(BASH_TACPLUS)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
 $(BASH_TACPLUS)_DEP_FILES   := $(DEP_FILES)
+
+
+
+
+SPATH       := $($(AUDISP_TACPLUS)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/tacacs.mk rules/tacacs.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+DEP_FILES   += $(shell git ls-files $(SPATH))
+
+$(AUDISP_TACPLUS)_CACHE_MODE  := GIT_CONTENT_SHA
+$(AUDISP_TACPLUS)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(AUDISP_TACPLUS)_DEP_FILES   := $(DEP_FILES)
 

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -22,6 +22,7 @@ FROM {{ prefix }}debian:bullseye
 MAINTAINER gulv@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-bullseye/apt-retries-count
+++ b/sonic-slave-bullseye/apt-retries-count
@@ -1,0 +1,1 @@
+Acquire::Retries "20";

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -21,6 +21,7 @@ FROM {{ prefix }}debian:buster
 MAINTAINER gulv@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-buster/apt-retries-count
+++ b/sonic-slave-buster/apt-retries-count
@@ -1,0 +1,1 @@
+Acquire::Retries "20";

--- a/sonic-slave-jessie/Dockerfile.j2
+++ b/sonic-slave-jessie/Dockerfile.j2
@@ -10,6 +10,7 @@ FROM {{ prefix }}debian:jessie
 MAINTAINER johnar@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 
 ## Remove retired jessie-updates repo
 RUN sed -i '/http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list

--- a/sonic-slave-jessie/apt-retries-count
+++ b/sonic-slave-jessie/apt-retries-count
@@ -1,0 +1,1 @@
+Acquire::Retries "20";

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -10,6 +10,7 @@ FROM {{ prefix }}debian:stretch
 MAINTAINER gulv@microsoft.com
 
 COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
 
 ## Make apt-get non-interactive

--- a/sonic-slave-stretch/apt-retries-count
+++ b/sonic-slave-stretch/apt-retries-count
@@ -1,0 +1,1 @@
+Acquire::Retries "20";

--- a/src/sonic-build-hooks/hooks/curl
+++ b/src/sonic-build-hooks/hooks/curl
@@ -3,4 +3,9 @@
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
 [ -z $REAL_COMMAND ] && REAL_COMMAND=/usr/bin/curl
 
-REAL_COMMAND=$REAL_COMMAND download_packages "$@"
+# Use --retry option for curl.
+# --retry - If a transient error is returned when curl tries to perform a
+# transfer, it will retry this number of times before giving up. Transient error
+# means either: a timeout, an FTP 4xx response code or an HTTP 408, 429, 500,
+# 502, 503 or 504 response code.
+REAL_COMMAND="$REAL_COMMAND --retry 5" download_packages "$@"

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -13,6 +13,7 @@ WEB_VERSION_FILE=$VERSION_PATH/versions-web
 BUILD_WEB_VERSION_FILE=$BUILD_VERSION_PATH/versions-web
 REPR_MIRROR_URL_PATTERN='http:\/\/packages.trafficmanager.net\/debian'
 DPKG_INSTALLTION_LOCK_FILE=/tmp/.dpkg_installation.lock
+GET_RETRY_COUNT=5
 
 . $BUILDINFO_PATH/config/buildinfo.config
 
@@ -132,8 +133,22 @@ download_packages()
         fi
     done
 
-    $REAL_COMMAND "${parameters[@]}"
-    local result=$?
+    # Retry if something super-weird has happened. Use --retry-connrefused
+    # option for wget/curl.
+    # --retry-connrefused - Consider "connection refused" a transient error and
+    # try again. Normally wget/curl gives up on a URL when it is unable to
+    # connect to the site because failure to connect is taken as a sign that the
+    # server is not running at all and that retries would not help. This option
+    # is for mirroring unreliable sites whose servers tend to disappear for
+    # short periods of time.
+    for ((i = 1; i <= GET_RETRY_COUNT; i++)); do
+        $REAL_COMMAND --retry-connrefused "${parameters[@]}"
+        local result=$?
+        if [ $result -eq 0 ]; then
+            break
+        fi
+        log_err "Try $i: $REAL_COMMAND failed to get: ${parameters[@]}. Retry.."
+    done
 
     for filename in "${!filenames[@]}"
     do


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix those errors:
One:
```
Connecting to urm.nvidia.com (urm.nvidia.com)|*.*.*.*|:443... connected.
GnuTLS: Error in the pull function.
Unable to establish SSL connection.
Error 4
make[1]: Leaving directory '/sonic/src/smartmontools'
[ target/debs/bullseye/smartmontools_6.6-1_amd64.deb ]
```
Second:
```
Get:90 https://debian-mirror-url buster/main amd64 librrd-dev amd64 1.7.1-2 [284 kB]
Get:91 https://debian-mirror-url buster/main amd64 psmisc amd64 23.2-1+deb10u1 [126 kB]
Get:92 https://debian-mirror-url buster/main amd64 python-smbus amd64 4.1-1 [12.2 kB]
Get:93 https://debian-mirror-url buster/main amd64 python3.7-dev amd64 3.7.3-2+deb10u3 [510 kB]
Get:94 https://debian-mirror-url buster/main amd64 python3-dev amd64 3.7.3-1 [1264 B]
Get:95 https://debian-mirror-url buster/main amd64 python3-smbus amd64 4.1-1 [12.5 kB]
Get:96 https://debian-mirror-url buster/main amd64 rrdtool amd64 1.7.1-2 [485 kB]
Fetched 122 MB in 12s (9976 kB/s)
[91mE: Failed to fetch https://debian-mirror-url/pool/main/p/python-defaults/python2-minimal_2.7.16-1_amd64.deb  500  Internal Server Error [IP: *.*.*.* 443]
E: Failed to fetch https://debian-mirror-url/pool/main/f/fontconfig/fontconfig-config_2.13.1-2_all.deb  500  Internal Server Error [IP: *.*.*.* 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
[0mThe command '/bin/sh -c apt-get update &&       apt-get install -y          build-essential         python3-dev             ipmitool                librrd8                 librrd-dev              rrdtool                 python-smbus            python3-smbus           dmidecode               i2c-tools               psmisc                  libpci3' returned a non-zero code: 100
[ target/docker-platform-monitor.gz ]
Error 1
```

#### How I did it
Add retry mechanism to apt, wget, and curl hooks

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### A picture of a cute animal (not mandatory but encouraged)
![1-46](https://user-images.githubusercontent.com/35844154/169010699-e61cb22f-c9ae-4d12-8ef1-64e3607eef4c.jpeg)
